### PR TITLE
Add support for map keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Package mold
 ============
-![Project status](https://img.shields.io/badge/version-2.1.0-green.svg)
+![Project status](https://img.shields.io/badge/version-2.2.0-green.svg)
 [![Build Status](https://travis-ci.org/go-playground/mold.svg?branch=v2)](https://travis-ci.org/go-playground/mold)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/mold/badge.svg?branch=v2)](https://coveralls.io/github/go-playground/mold?branch=v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/mold)](https://goreportcard.com/report/github.com/go-playground/mold)

--- a/_examples/full/main.go
+++ b/_examples/full/main.go
@@ -44,12 +44,13 @@ type Address struct {
 
 // User contains user information
 type User struct {
-	Name    string    `mod:"trim"      validate:"required"              scrub:"name"`
-	Age     uint8     `                validate:"required,gt=0,lt=130"`
-	Gender  string    `                validate:"required"`
-	Email   string    `mod:"trim"      validate:"required,email"        scrub:"emails"`
-	Address []Address `                validate:"required,dive"`
-	Active  bool      `form:"active"`
+	Name    string            `mod:"trim"      validate:"required"              scrub:"name"`
+	Age     uint8             `                validate:"required,gt=0,lt=130"`
+	Gender  string            `                validate:"required"`
+	Email   string            `mod:"trim"      validate:"required,email"        scrub:"emails"`
+	Address []Address         `                validate:"required,dive"`
+	Active  bool              `form:"active"`
+	Misc    map[string]string `mod:"dive,keys,trim,endkeys,trim"`
 }
 
 func main() {
@@ -108,5 +109,6 @@ func parseForm() url.Values {
 		"Address[1].Name":  []string{"26 There Blvd."},
 		"Address[1].Phone": []string{"1(111)111-1111"},
 		"active":           []string{"true"},
+		"Misc[  b4  ]":     []string{"  b4  "},
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,17 @@ import (
 	"strings"
 )
 
+var (
+	// ErrInvalidDive describes an invalid dive tag configuration
+	ErrInvalidDive = errors.New("Invalid dive tag configuration")
+
+	// ErrUndefinedKeysTag describes an undefined keys tag when and endkeys tag defined
+	ErrUndefinedKeysTag = errors.New("'" + endKeysTag + "' tag encountered without a corresponding '" + keysTag + "' tag")
+
+	// ErrInvalidKeysTag describes a misuse of the keys tag
+	ErrInvalidKeysTag = errors.New("'" + keysTag + "' tag must be immediately preceeded by the '" + diveTag + "' tag")
+)
+
 // ErrUndefinedTag defines a tag that does not exist
 type ErrUndefinedTag struct {
 	tag   string
@@ -58,6 +69,3 @@ type ErrInvalidTransformation struct {
 func (e *ErrInvalidTransformation) Error() string {
 	return "mold: (nil " + e.typ.String() + ")"
 }
-
-// ErrInvalidDive describes an invalid dive tag configuration
-var ErrInvalidDive = errors.New("Invalid dive tag configuration")

--- a/restricted.go
+++ b/restricted.go
@@ -3,6 +3,12 @@ package mold
 const (
 	diveTag            = "dive"
 	restrictedTagChars = ".[],|=+()`~!@#$%^&*\\\"/?<>{}"
+	tagSeparator    = ","
+	ignoreTag       = "-"
+	tagKeySeparator = "="
+	utf8HexComma    = "0x2C"
+	keysTag            = "keys"
+	endKeysTag         = "endkeys"
 )
 
 var (


### PR DESCRIPTION
Added map key support with new `keys` and `endkeys` eg.

```go
type Test struct {
  Map map[string]string `mold:"dive,keys,trim,endkeys,trim"`
}
```

`keys` must be directly after the dive tag; this was done for efficiency to allow map keys and values to be br handled within the same range.