### PR TITLE
Updates2

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: go test -race -covermode=atomic -coverprofile="profile.cov" ./...
 
       - name: Send Coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.15.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.16.x'
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: profile.cov

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,4 +45,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.41.1

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 GOCMD=GO111MODULE=on go
 
+lint:
+	golangci-lint run
+
 test:
 	$(GOCMD) test -cover -race ./...
 
 bench:
 	$(GOCMD) test -bench=. -benchmem ./...
 
-.PHONY: test bench
+.PHONY: test bench lint

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ test:
 bench:
 	$(GOCMD) test -bench=. -benchmem ./...
 
-.PHONY: linters-install lint test bench
+.PHONY: test bench

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Package mold
 ============
-![Project status](https://img.shields.io/badge/version-4.0.0-green.svg)
+![Project status](https://img.shields.io/badge/version-4.1.0-green.svg)
 [![Build Status](https://travis-ci.org/go-playground/mold.svg?branch=v2)](https://travis-ci.org/go-playground/mold)
 [![Coverage Status](https://coveralls.io/repos/github/go-playground/mold/badge.svg?branch=v2)](https://coveralls.io/github/go-playground/mold?branch=v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/mold)](https://goreportcard.com/report/github.com/go-playground/mold)

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/segmentio/go-camelcase v0.0.0-20160726192923-7085f1e3c734
 	github.com/segmentio/go-snakecase v1.2.0
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,17 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/segmentio/go-camelcase v0.0.0-20160726192923-7085f1e3c734 h1:Cpx2WLIv6fuPvaJAHNhYOgYzk/8RcJXu/8+mOrxf2KM=
 github.com/segmentio/go-camelcase v0.0.0-20160726192923-7085f1e3c734/go.mod h1:hqVOMAwu+ekffC3Tvq5N1ljnXRrFKcaSjbCmQ8JgYaI=
 github.com/segmentio/go-snakecase v1.2.0 h1:4cTmEjPGi03WmyAHWBjX53viTpBkn/z+4DO++fqYvpw=
 github.com/segmentio/go-snakecase v1.2.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/modifiers/multi.go
+++ b/modifiers/multi.go
@@ -2,10 +2,15 @@ package modifiers
 
 import (
 	"context"
+	"reflect"
 	"strconv"
 	"time"
 
 	"github.com/go-playground/mold/v4"
+)
+
+var (
+	durationType = reflect.TypeOf(time.Duration(0))
 )
 
 //
@@ -16,44 +21,56 @@ func defaultValue(ctx context.Context, fl mold.FieldLevel) error {
 		return nil
 	}
 
-	switch fl.Field().Interface().(type) {
-	case string:
+	switch fl.Field().Kind() {
+	case reflect.String:
 		fl.Field().SetString(fl.Param())
 
-	case int, int8, int16, int32, int64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
 		value, err := strconv.Atoi(fl.Param())
 		if err != nil {
 			return err
 		}
 		fl.Field().SetInt(int64(value))
 
-	case uint, uint8, uint16, uint32, uint64:
+	case reflect.Int64:
+		var value int64
+
+		if fl.Field().Type() == durationType {
+			d, err := time.ParseDuration(fl.Param())
+			if err != nil {
+				return err
+			}
+			value = int64(d)
+		} else {
+			i, err := strconv.Atoi(fl.Param())
+			if err != nil {
+				return err
+			}
+			value = int64(i)
+		}
+		fl.Field().SetInt(value)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		value, err := strconv.Atoi(fl.Param())
 		if err != nil {
 			return err
 		}
 		fl.Field().SetUint(uint64(value))
 
-	case float32, float64:
+	case reflect.Float32, reflect.Float64:
 		value, err := strconv.ParseFloat(fl.Param(), 64)
 		if err != nil {
 			return err
 		}
 		fl.Field().SetFloat(value)
 
-	case bool:
+	case reflect.Bool:
 		value, err := strconv.ParseBool(fl.Param())
 		if err != nil {
 			return err
 		}
 		fl.Field().SetBool(value)
 
-	case time.Duration:
-		d, err := time.ParseDuration(fl.Param())
-		if err != nil {
-			return err
-		}
-		fl.Field().SetInt(int64(d))
 	}
 	return nil
 }

--- a/modifiers/multi_test.go
+++ b/modifiers/multi_test.go
@@ -9,6 +9,13 @@ import (
 )
 
 func TestDefault(t *testing.T) {
+
+	type State int
+	const READY State = 0
+	const FINISHED State = 5
+
+	var state State
+
 	conform := New()
 
 	tests := []struct {
@@ -18,6 +25,12 @@ func TestDefault(t *testing.T) {
 		expected    interface{}
 		expectError bool
 	}{
+		{
+			name:     "default State (although enum default value should be the default in practice)",
+			field:    state,
+			tags:     "default=5",
+			expected: FINISHED,
+		},
 		{
 			name:     "default string",
 			field:    "",

--- a/modifiers/multi_test.go
+++ b/modifiers/multi_test.go
@@ -11,7 +11,6 @@ import (
 func TestDefault(t *testing.T) {
 
 	type State int
-	const READY State = 0
 	const FINISHED State = 5
 
 	var state State

--- a/modifiers/string.go
+++ b/modifiers/string.go
@@ -3,6 +3,7 @@ package modifiers
 import (
 	"bytes"
 	"context"
+	"reflect"
 	"regexp"
 	"strings"
 	"unicode"
@@ -15,91 +16,82 @@ import (
 
 // trimSpace trims extra space from text
 func trimSpace(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.TrimSpace(fl.Field().String()))
 	}
-	fl.Field().SetString(strings.TrimSpace(s))
 	return nil
 }
 
 // trimLeft trims extra left hand side of string using provided cutset
 func trimLeft(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.TrimLeft(fl.Field().String(), fl.Param()))
 	}
-	fl.Field().SetString(strings.TrimLeft(s, fl.Param()))
 	return nil
 }
 
 // trimRight trims extra right hand side of string using provided cutset
 func trimRight(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.TrimRight(fl.Field().String(), fl.Param()))
 	}
-	fl.Field().SetString(strings.TrimRight(s, fl.Param()))
 	return nil
 }
 
 // trimPrefix trims the string of a prefix
 func trimPrefix(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.TrimPrefix(fl.Field().String(), fl.Param()))
 	}
-	fl.Field().SetString(strings.TrimPrefix(s, fl.Param()))
 	return nil
 }
 
 // trimSuffix trims the string of a suffix
 func trimSuffix(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.TrimSuffix(fl.Field().String(), fl.Param()))
 	}
-	fl.Field().SetString(strings.TrimSuffix(s, fl.Param()))
 	return nil
 }
 
 // toLower convert string to lower case
 func toLower(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.ToLower(fl.Field().String()))
 	}
-	fl.Field().SetString(strings.ToLower(s))
 	return nil
 }
 
 // toUpper convert string to upper case
 func toUpper(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.ToUpper(fl.Field().String()))
 	}
-	fl.Field().SetString(strings.ToUpper(s))
 	return nil
 }
 
 // snakeCase converts string to snake case
 func snakeCase(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(snakecase.Snakecase(fl.Field().String()))
 	}
-	fl.Field().SetString(snakecase.Snakecase(s))
 	return nil
 }
 
 // titleCase converts string to title case, e.g. "this is a sentence" -> "This Is A Sentence"
 func titleCase(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.Title(fl.Field().String()))
 	}
-	fl.Field().SetString(strings.Title(s))
 	return nil
 }
 
@@ -118,11 +110,10 @@ var nameRegex = regexp.MustCompile(`[\p{L}]([\p{L}|[:space:]\-']*[\p{L}])*`)
 // Example: "3493€848Jo-$%£@Ann " -> "Jo-Ann", " ~~ The Dude ~~" -> "The Dude", "**susan**" -> "Susan",
 // " hugh fearnley-whittingstall" -> "Hugh Fearnley-Whittingstall"
 func nameCase(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(strings.Title(nameRegex.FindString(onlyOne(strings.ToLower(fl.Field().String())))))
 	}
-	fl.Field().SetString(strings.Title(nameRegex.FindString(onlyOne(strings.ToLower(s)))))
 	return nil
 }
 
@@ -137,21 +128,22 @@ func onlyOne(s string) string {
 
 // uppercaseFirstCharacterCase converts a string so that it has only the first capital letter. Example: "all lower" -> "All lower"
 func uppercaseFirstCharacterCase(_ context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		s := fl.Field().String()
+		if s == "" {
+			return nil
+		}
+
+		toRune, size := utf8.DecodeRuneInString(s)
+		if !unicode.IsLower(toRune) {
+			return nil
+		}
+		buf := &bytes.Buffer{}
+		buf.WriteRune(unicode.ToUpper(toRune))
+		buf.WriteString(s[size:])
+		fl.Field().SetString(buf.String())
 	}
-	if s == "" {
-		return nil
-	}
-	toRune, size := utf8.DecodeRuneInString(s)
-	if !unicode.IsLower(toRune) {
-		return nil
-	}
-	buf := &bytes.Buffer{}
-	buf.WriteRune(unicode.ToUpper(toRune))
-	buf.WriteString(s[size:])
-	fl.Field().SetString(buf.String())
 	return nil
 }
 
@@ -159,11 +151,10 @@ var stripNumRegex = regexp.MustCompile("[^0-9]")
 
 // stripAlphaCase removes all non-numeric characters. Example: "the price is €30,38" -> "3038". Note: The struct field will remain a string. No type conversion takes place.
 func stripAlphaCase(_ context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(stripNumRegex.ReplaceAllLiteralString(fl.Field().String(), ""))
 	}
-	fl.Field().SetString(stripNumRegex.ReplaceAllLiteralString(s, ""))
 	return nil
 }
 
@@ -171,11 +162,10 @@ var stripAlphaRegex = regexp.MustCompile("[0-9]")
 
 // stripNumCase removes all numbers. Example "39472349D34a34v69e8932747" -> "Dave". Note: The struct field will remain a string. No type conversion takes place.
 func stripNumCase(_ context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(stripAlphaRegex.ReplaceAllLiteralString(fl.Field().String(), ""))
 	}
-	fl.Field().SetString(stripAlphaRegex.ReplaceAllLiteralString(s, ""))
 	return nil
 }
 
@@ -183,11 +173,10 @@ var stripNumUnicodeRegex = regexp.MustCompile(`[^\pL]`)
 
 // stripNumUnicodeCase removes non-alpha unicode characters. Example: "!@£$%^&'()Hello 1234567890 World+[];\" -> "HelloWorld"
 func stripNumUnicodeCase(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(stripNumUnicodeRegex.ReplaceAllLiteralString(fl.Field().String(), ""))
 	}
-	fl.Field().SetString(stripNumUnicodeRegex.ReplaceAllLiteralString(s, ""))
 	return nil
 }
 
@@ -195,20 +184,18 @@ var stripAlphaUnicode = regexp.MustCompile(`[\pL]`)
 
 // stripAlphaUnicodeCase removes alpha unicode characters. Example: "Everything's here but the letters!" -> "' !"
 func stripAlphaUnicodeCase(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(stripAlphaUnicode.ReplaceAllLiteralString(fl.Field().String(), ""))
 	}
-	fl.Field().SetString(stripAlphaUnicode.ReplaceAllLiteralString(s, ""))
 	return nil
 }
 
 // camelCase converts string to camel case
 func camelCase(ctx context.Context, fl mold.FieldLevel) error {
-	s, ok := fl.Field().Interface().(string)
-	if !ok {
-		return nil
+	switch fl.Field().Kind() {
+	case reflect.String:
+		fl.Field().SetString(camelcase.Camelcase(fl.Field().String()))
 	}
-	fl.Field().SetString(camelcase.Camelcase(s))
 	return nil
 }

--- a/modifiers/string_test.go
+++ b/modifiers/string_test.go
@@ -2,8 +2,11 @@ package modifiers
 
 import (
 	"context"
+	"database/sql"
 	"log"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -807,3 +810,85 @@ func TestCamelCase(t *testing.T) {
 		t.Fatalf("Unexpected value '%v'\n", iface)
 	}
 }
+
+func TestString(t *testing.T) {
+	assert := require.New(t)
+	conform := New()
+
+	conform.RegisterInterceptor(func(current reflect.Value) (inner reflect.Value) {
+		current.FieldByName("Valid").SetBool(true)
+		return current.FieldByName("String")
+	}, sql.NullString{})
+
+	tests := []struct {
+		name        string
+		field       interface{}
+		tags        string
+		expected    interface{}
+		expectError bool
+	}{
+		{
+			name:     "test Camel Case",
+			field:    "this_is_snakecase",
+			tags:     "camel",
+			expected: "thisIsSnakecase",
+		},
+		{
+			name: "test Camel Case struct",
+			field: struct {
+				String string `mod:"camel"`
+			}{String: "this_is_snakecase"},
+			tags: "camel",
+			expected: struct {
+				String string `mod:"camel"`
+			}{String: "thisIsSnakecase"},
+		},
+		{
+			name:     "sql.nullString lcase",
+			field:    sql.NullString{String: "UPPERCASE", Valid: true},
+			tags:     "lcase",
+			expected: sql.NullString{String: "uppercase", Valid: true},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var err error
+
+			input := reflect.ValueOf(tc.field)
+			if !input.CanAddr() {
+				// create NEW addressable pointer to struct and assign the old unadressable one.
+				// sort fo like:
+				//
+				// var newStruct *oldstructdef
+				// *newStruct = *&oldStruct
+				//
+				newVal := reflect.New(input.Type())
+				newVal.Elem().Set(input)
+				tc.field = newVal.Interface()
+			}
+
+			if reflect.ValueOf(tc.field).Kind() == reflect.Struct && !excludedStructs[reflect.TypeOf(tc.field)] {
+				err = conform.Struct(context.Background(), &tc.field)
+			} else {
+				err = conform.Field(context.Background(), &tc.field, tc.tags)
+			}
+
+			if tc.expectError {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tc.expected, reflect.Indirect(reflect.ValueOf(tc.field)).Interface())
+		})
+	}
+}
+
+var (
+	excludedStructs = map[reflect.Type]bool{
+		reflect.TypeOf(time.Time{}):      true,
+		reflect.TypeOf(sql.NullString{}): true,
+	}
+)

--- a/modifiers/string_test.go
+++ b/modifiers/string_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // NOTES:
@@ -16,6 +18,19 @@ import (
 // -- may be a good idea to change to output path to somewherelike /tmp
 // go test -coverprofile cover.out && go tool cover -html=cover.out -o cover.html
 //
+
+func TestEnumType(t *testing.T) {
+	assert := require.New(t)
+
+	type State string
+	const START State = "start"
+	state := State("START")
+
+	conform := New()
+	err := conform.Field(context.Background(), &state, "lcase")
+	assert.NoError(err)
+	assert.Equal(START, state)
+}
 
 func TestEmails(t *testing.T) {
 	conform := New()
@@ -599,7 +614,7 @@ func TestNumCase(t *testing.T) {
 	}
 
 	iface = s
-  
+
 	err = conform.Field(context.Background(), &iface, "strip_alpha")
 	if err != nil {
 		log.Fatal(err)

--- a/util.go
+++ b/util.go
@@ -5,21 +5,24 @@ import (
 )
 
 // extractType gets the actual underlying type of field value.
-func extractType(current reflect.Value) (reflect.Value, reflect.Kind) {
+func (t *Transformer) extractType(current reflect.Value) (reflect.Value, reflect.Kind) {
 	switch current.Kind() {
 	case reflect.Ptr:
 		if current.IsNil() {
 			return current, reflect.Ptr
 		}
-		return extractType(current.Elem())
+		return t.extractType(current.Elem())
 
 	case reflect.Interface:
 		if current.IsNil() {
 			return current, reflect.Interface
 		}
-		return extractType(current.Elem())
+		return t.extractType(current.Elem())
 
 	default:
+		if fn := t.interceptors[current.Type()]; fn != nil {
+			return t.extractType(fn(current))
+		}
 		return current, current.Kind()
 	}
 }


### PR DESCRIPTION
## PR
- Updated modifiers to support more types using reflection instead of type casting.
- Added `Interceptors` which can redirect the value modifiers are applied to eg. the `String` of an `sql.NullString`