### PR TITLE
Comment typo in full example

### DIFF
--- a/_examples/full/main.go
+++ b/_examples/full/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 	fmt.Printf("Decoded:%+v\n\n", user)
 
-	// great not lets conform our values, after all a human input the data
+	// great now lets conform our values, after all a human input the data
 	// nobody's perfect
 	err = conform.Struct(context.Background(), &user)
 	if err != nil {


### PR DESCRIPTION
The comment was misleading using "not" instead of what I assumed should be "now"