### PR TITLE
fix slice pointer dive tag

### DIFF
--- a/mold.go
+++ b/mold.go
@@ -234,6 +234,10 @@ func (t *Transformer) setByField(ctx context.Context, orig reflect.Value, ct *cT
 			case typeDive:
 				ct = ct.next
 
+				if kind == reflect.Ptr && current.IsNil() {
+					return
+				}
+
 				switch kind {
 				case reflect.Slice, reflect.Array:
 					err = t.setByIterable(ctx, current, ct)
@@ -257,7 +261,6 @@ func (t *Transformer) setByField(ctx context.Context, orig reflect.Value, ct *cT
 						return
 					}
 					orig.Set(reflect.Indirect(newVal))
-					current, kind = t.extractType(orig)
 				} else {
 					if err = ct.fn(ctx, fieldLevel{
 						transformer: t,
@@ -268,6 +271,8 @@ func (t *Transformer) setByField(ctx context.Context, orig reflect.Value, ct *cT
 						return
 					}
 				}
+				current, kind = t.extractType(orig)
+
 				ct = ct.next
 			}
 		}


### PR DESCRIPTION
When `orig` is pointer, not only `!current.CanAddr()` but also `else` modify `orig`, so call `t.extractType(orig)` both cases.
If a value is set from nil,`kind` is reassigned from ptr to slice, map.

And I would prefer to allow the following cases.

```go
type Foo struct { Bars: *[]Bar `mold:"dive"` }

f1 := Foo{ Bars: &[]Bar{} } // No problem with the status quo.
f2 := Foo{ Bars: nil } // Now "invalid dive tag configuration" error returns.
```