### PR TITLE
Fix email scrubber hash input

### DIFF
--- a/scrubbers/string.go
+++ b/scrubbers/string.go
@@ -14,7 +14,7 @@ var (
 	emailRegex      = regexp.MustCompile("(?:(?:(?:(?:[a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+(?:\\.(?:[a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+)*)|(?:(?:\\x22)(?:(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(?:\\x20|\\x09)+)?(?:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:\\(?:[\\x01-\\x09\\x0b\\x0c\\x0d-\\x7f]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]))))*(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(\\x20|\\x09)+)?(?:\\x22)))@(?:(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|_|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.)+(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|_|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.?(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+")
 	emailSubmatchFn = func(input string) string {
 		idx := strings.IndexByte(input, '@')
-		scrubbed := fmt.Sprintf("<<scrubbed::email::sha1::%s>>", hashString(input[idx:]))
+		scrubbed := fmt.Sprintf("<<scrubbed::email::sha1::%s>>", hashString(input[:idx]))
 		return scrubbed + input[idx:]
 	}
 )

--- a/scrubbers/string_test.go
+++ b/scrubbers/string_test.go
@@ -29,11 +29,11 @@ func TestEmails(t *testing.T) {
 	tt := Test{Email: email}
 	err := scrub.Struct(context.Background(), &tt)
 	Equal(t, err, nil)
-	Equal(t, tt.Email, "<<scrubbed::email::sha1::5131512f2d165ca283b055bc6f32bc01dd23121e>>@gmail.com")
+	Equal(t, tt.Email, "<<scrubbed::email::sha1::c52a47d4f3cde7c83046fc1fc8f208df74833cfa>>@gmail.com")
 
 	err = scrub.Field(context.Background(), &email, "emails")
 	Equal(t, err, nil)
-	Equal(t, email, "<<scrubbed::email::sha1::5131512f2d165ca283b055bc6f32bc01dd23121e>>@gmail.com")
+	Equal(t, email, "<<scrubbed::email::sha1::c52a47d4f3cde7c83046fc1fc8f208df74833cfa>>@gmail.com")
 
 	var iface interface{}
 	err = scrub.Field(context.Background(), &iface, "emails")
@@ -43,7 +43,15 @@ func TestEmails(t *testing.T) {
 	iface = "Dean.Karn@gmail.com"
 	err = scrub.Field(context.Background(), &iface, "emails")
 	Equal(t, err, nil)
-	Equal(t, iface, "<<scrubbed::email::sha1::5131512f2d165ca283b055bc6f32bc01dd23121e>>@gmail.com")
+	Equal(t, iface, "<<scrubbed::email::sha1::c52a47d4f3cde7c83046fc1fc8f208df74833cfa>>@gmail.com")
+
+	emailText := "alice@example.com bob@example.com"
+	err = scrub.Field(context.Background(), &emailText, "emails")
+	Equal(t, err, nil)
+	Equal(t, emailText,
+		"<<scrubbed::email::sha1::522b276a356bdf39013dfabea2cd43e141ecc9e8>>@example.com "+
+			"<<scrubbed::email::sha1::48181acd22b3edaebc8a447868a7df7ce629920a>>@example.com",
+	)
 }
 
 func TestText(t *testing.T) {


### PR DESCRIPTION
Fixes #45

## Summary
- hash the email local part when using the `emails` scrubber
- keep the existing behavior of replacing the local part and preserving the original domain
- add coverage for multiple emails with the same domain so different local parts no longer collapse to the same scrub hash

## Verification
- RED: `go test ./scrubbers -run TestEmails -count=1` failed before the fix because `alice@example.com` and `bob@example.com` produced the same hash
- `go test ./scrubbers -run TestEmails -count=1`
- `go test ./...`
- `git diff --check`
